### PR TITLE
Add support for controlled input components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode } from "react";
 
 interface InnerText {
   (jsx: ReactNode): string;
@@ -6,47 +6,51 @@ interface InnerText {
 }
 
 const hasProps = (jsx: ReactNode): jsx is ReactElement =>
-  Object.prototype.hasOwnProperty.call(jsx, 'props');
+  Object.prototype.hasOwnProperty.call(jsx, "props");
 
 const reduceJsxToString = (previous: string, current: ReactNode): string =>
   previous + innerText(current);
 
 const innerText: InnerText = (jsx: ReactNode): string => {
-
   // Empty
-  if (
-    jsx === null ||
-    typeof jsx === 'boolean' ||
-    typeof jsx === 'undefined'
-  ) {
-    return '';
+  if (jsx === null || typeof jsx === "boolean" || typeof jsx === "undefined") {
+    return "";
   }
 
   // Numeric children.
-  if (typeof jsx === 'number') {
+  if (typeof jsx === "number") {
     return jsx.toString();
   }
 
   // String literals.
-  if (typeof jsx === 'string') {
+  if (typeof jsx === "string") {
     return jsx;
   }
 
   // Array of JSX.
   if (Array.isArray(jsx)) {
-    return jsx.reduce<string>(reduceJsxToString, '');
+    return jsx.reduce<string>(reduceJsxToString, "");
   }
 
   // Children prop.
   if (
     hasProps(jsx) &&
-    Object.prototype.hasOwnProperty.call(jsx.props, 'children')
+    Object.prototype.hasOwnProperty.call(jsx.props, "children")
   ) {
     return innerText(jsx.props.children);
   }
 
+  if (hasProps(jsx)) {
+    if (Object.prototype.hasOwnProperty.call(jsx.props, "value")) {
+      return innerText(jsx.props.value);
+    }
+    if (Object.prototype.hasOwnProperty.call(jsx.props, "checked")) {
+      return String(jsx.props.checked);
+    }
+  }
+
   // Default
-  return '';
+  return "";
 };
 
 innerText.default = innerText;

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,71 +1,90 @@
-import * as React from 'react';
-import { expect } from 'chai';
-import innerText from '../index';
+import * as React from "react";
+import { expect } from "chai";
+import innerText from "../src/index";
 
 interface HasWindow extends NodeJS.Global {
-	window: Window;
+  window: Window;
 }
 
 const hasWindow = (obj: NodeJS.Global): obj is HasWindow =>
-	Object.prototype.hasOwnProperty.call(obj, 'window');
+  Object.prototype.hasOwnProperty.call(obj, "window");
 
 if (hasWindow(global)) {
-	delete global.window;
+  delete global.window;
 }
 
-describe('react-innertext', (): void => {
+describe("react-innertext", (): void => {
+  it("should support a window-less environment", (): void => {
+    expect((global as HasWindow).window).to.be.undefined;
+    // @ts-ignore
+    expect(typeof window).to.equal("undefined");
+  });
 
-	it('should support a window-less environment', (): void => {
-		expect((global as HasWindow).window).to.be.undefined;
-		// @ts-ignore
-		expect(typeof window).to.equal('undefined');
-	});
+  it("should support boolean", (): void => {
+    expect(innerText(true)).to.equal("");
+    expect(innerText(false)).to.equal("");
+  });
 
-	it('should support boolean', (): void => {
-		expect(innerText(true)).to.equal('');
-		expect(innerText(false)).to.equal('');
-	});
+  it("should support empty objects", (): void => {
+    expect(innerText({})).to.equal("");
+  });
 
-	it('should support empty objects', (): void => {
-		expect(innerText({})).to.equal('');
-	});
+  it("should support null", (): void => {
+    expect(innerText(null)).to.equal("");
+  });
 
-	it('should support null', (): void => {
-		expect(innerText(null)).to.equal('');
-	});
+  it("should support numbers", (): void => {
+    expect(innerText(123)).to.equal("123");
+    expect(innerText(420.69)).to.equal("420.69");
+  });
 
-	it('should support numbers', (): void => {
-		expect(innerText(123)).to.equal('123');
-		expect(innerText(420.69)).to.equal('420.69');
-	});
+  it("should support undefined", (): void => {
+    expect(innerText(undefined)).to.equal("");
+  });
 
-	it('should support undefined', (): void => {
-		expect(innerText(undefined)).to.equal('');
-	});
+  it("should support ReactElements", (): void => {
+    expect(innerText(<div>This is a div.</div>)).to.equal("This is a div.");
+  });
 
-	it('should support ReactElements', (): void => {
-		expect(innerText(<div>This is a div.</div>)).to.equal('This is a div.');
-	});
+  it("should support childless ReactElements", (): void => {
+    expect(innerText(<div />)).to.equal("");
+  });
 
-	it('should support childless ReactElements', (): void => {
-		expect(innerText(<div />)).to.equal('');
-	});
+  it("should support nested ReactElements", (): void => {
+    expect(
+      innerText(
+        <div>
+          <p>Paragraph 1.</p>
+          <p>Paragraph 2.</p>
+        </div>
+      )
+    ).to.equal("Paragraph 1.Paragraph 2.");
+  });
 
-	it('should support nested ReactElements', (): void => {
-		expect(innerText(<div><p>Paragraph 1.</p><p>Paragraph 2.</p></div>))
-			.to.equal('Paragraph 1.Paragraph 2.');
-	});
+  it("should support arrays", (): void => {
+    expect(
+      innerText([
+        null,
+        123,
+        undefined,
+        true,
+        <p>1</p>,
+        ["te", "st"],
+        420.69,
+        <div>
+          <span>2</span>
+          <span>three</span>
+          <p>4</p>
+        </div>
+      ])
+    ).to.equal("1231test420.692three4");
+  });
 
-	it('should support arrays', (): void => {
-		expect(innerText([
-			null,
-			123,
-			undefined,
-			true,
-			<p>1</p>,
-			[ 'te', 'st' ],
-			420.69,
-			<div><span>2</span><span>three</span><p>4</p></div>
-		])).to.equal('1231test420.692three4');
-	});
+  it("should support controlled input via value prop", (): void => {
+    expect(innerText(<input value="testing" />)).to.equal("testing");
+  });
+
+  it("should support controlled input via checked prop", (): void => {
+    expect(innerText(<input checked={true} />)).to.equal("true");
+  });
 });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { expect } from "chai";
-import innerText from "../src/index";
+import innerText from "../index";
 
 interface HasWindow extends NodeJS.Global {
   window: Window;


### PR DESCRIPTION
Added support for React controlled components (with the 'value' and 'checked' props). It may not work for other inputs, but at least would be effective on controlled components.